### PR TITLE
[FIX] Added headers to workspace/export request when using token.

### DIFF
--- a/R/export_from_workspace.R
+++ b/R/export_from_workspace.R
@@ -80,6 +80,7 @@ export_from_workspace <- function(workspace_path, format,
                                   utils::URLencode(workspace_path),
                                   "&direct_download=",
                                   direct_download),
+                     httr::add_headers(headers),
                      httr::content_type_json())
   }
 


### PR DESCRIPTION
The `export_from_workspace` function wasn't working when providing the access token in the code instead of a `.netrc` file. Reason for this is that the headers were missing. In this PR, I've added those headers so that `export_from_workspace` works properly in this case.